### PR TITLE
[BB-4023] Create custom eCommerce client and automate credential sharing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run-lms: ## Generate microsite configuration in LMS
 run-discovery: ## Generate microsite configuration in Discovery
 	bash -c "source /edx/app/discovery/discovery_env && python scripts/generate_discovery.py config/config.yaml --settings course_discovery.settings.production"
 
-run-ecommerce:  ## Generate microsite configuration in eCommerce
+run-ecommerce:  ## Generate microsite configuration in eCommerce. Must be run after `run-lms`
 	bash -c "source /edx/app/ecommerce/ecommerce_env && python scripts/generate_ecommerce.py config/config.yaml --settings ecommerce.settings.production"
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ dev.run-ecommerce:   Devstack - Generate microsite configuration in eCommerce
 `config/config.yaml` file contains following features -
 
 - `main_domain`: The base domain. Each microsite will be set as subdomain of this domain.
+- `oauth`: OAuth applications in LMS
+    1. `ecommerce_sso_client`: eCommerce SSO Client name, defaults to `custom-sites-ecommerce-sso`. It is intentionally a different one than the one found by default in an Open edX installation, since the default one resets on every deployment. But we need to have redirect URIs for dynamic custom sites. Generator will create this client autometically if not found.
+    2. `ecommerce_backend_service_client`: eCommerce backend worker client name. Defaults to `ecommerce-backend-service`, which is available by default in an Open edX installation. Generator will not create this client autometically.
 - `site_for_each_organization`: Set this to `true` if each organization will have a microsite. Then the script will automatically copy `organizations` as `microsites`.
 - `organizations`: A dictionary containing organization related info
     ```yaml

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ dev.run-ecommerce:   Devstack - Generate microsite configuration in eCommerce
 
 - `main_domain`: The base domain. Each microsite will be set as subdomain of this domain.
 - `oauth`: OAuth applications in LMS
-    1. `ecommerce_sso_client`: eCommerce SSO Client name, defaults to `custom-sites-ecommerce-sso`. It is intentionally a different one than the one found by default in an Open edX installation, since the default one resets on every deployment. But we need to have redirect URIs for dynamic custom sites. Generator will create this client autometically if not found.
-    2. `ecommerce_backend_service_client`: eCommerce backend worker client name. Defaults to `ecommerce-backend-service`, which is available by default in an Open edX installation. Generator will not create this client autometically.
+    - `ecommerce_sso_client`: eCommerce SSO Client name, defaults to `custom-sites-ecommerce-sso`. It is intentionally a different one than the one found by default in an Open edX installation, since the default one resets on every deployment. But we need to have redirect URIs for dynamic custom sites. Generator will create this client autometically if not found.
 - `site_for_each_organization`: Set this to `true` if each organization will have a microsite. Then the script will automatically copy `organizations` as `microsites`.
 - `organizations`: A dictionary containing organization related info
     ```yaml

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,1 +1,3 @@
-config.yaml
+*
+!sample.yaml
+!.gitignore

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -1,5 +1,8 @@
 main_domain: "example.com"
 site_for_each_organization: true
+oauth:
+  ecommerce_sso_client: custom-sites-ecommerce-sso
+  ecommerce_backend_service_client: ecommerce-backend-service
 organizations:
   A:
     name: "A Organization"

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -2,7 +2,6 @@ main_domain: "example.com"
 site_for_each_organization: true
 oauth:
   ecommerce_sso_client: custom-sites-ecommerce-sso
-  ecommerce_backend_service_client: ecommerce-backend-service
 organizations:
   A:
     name: "A Organization"

--- a/scripts/const.py
+++ b/scripts/const.py
@@ -3,5 +3,5 @@ DISCOVERY_ROOT_DIR = '/edx/app/discovery/discovery'
 ECOMMERCE_ROOT_DIR = '/edx/app/ecommerce/ecommerce'
 LMS_ROOT_DIR = '/edx/app/edxapp/edx-platform'
 
-
-ECOMMERCE_SSO_CLIENT = 'ecommerce-sso'
+# don't modify this file, as this gets created dynamicly everytime we run the generator
+GENERATED_SHARED_CONFIG_FILE = 'config/_generated.yaml'

--- a/scripts/const.py
+++ b/scripts/const.py
@@ -3,5 +3,5 @@ DISCOVERY_ROOT_DIR = '/edx/app/discovery/discovery'
 ECOMMERCE_ROOT_DIR = '/edx/app/ecommerce/ecommerce'
 LMS_ROOT_DIR = '/edx/app/edxapp/edx-platform'
 
-# don't modify this file, as this gets created dynamicly everytime we run the generator
+# don't modify this file, as this gets created dynamically everytime we run the generator
 GENERATED_SHARED_CONFIG_FILE = 'config/_generated.yaml'

--- a/scripts/generate_ecommerce.py
+++ b/scripts/generate_ecommerce.py
@@ -3,7 +3,7 @@ import sys
 import os
 import logging
 from const import ECOMMERCE_ROOT_DIR
-from generator_utils import load_config, common_args, update_model
+from generator_utils import load_config, common_args, update_model, load_generated_values
 
 
 logger = logging.getLogger(__name__)
@@ -72,6 +72,8 @@ def create_site_configuration(config, sites, partners):
     """
     from ecommerce.core.models import SiteConfiguration
 
+    generated_values = load_generated_values()
+
     for code in config.get_microsite_codes():
         context = config.get_context(code)
 
@@ -85,7 +87,11 @@ def create_site_configuration(config, sites, partners):
                 'SOCIAL_AUTH_EDX_OAUTH2_ISSUERS': [
                     context['lms_url']
                 ],
-                'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': '{}/logout'.format(context['lms_url'])
+                'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': '{}/logout'.format(context['lms_url']),
+                'SOCIAL_AUTH_EDX_OAUTH2_KEY': generated_values.get('SOCIAL_AUTH_EDX_OAUTH2_KEY'),
+                'SOCIAL_AUTH_EDX_OAUTH2_SECRET': generated_values.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET'),
+                'BACKEND_SERVICE_EDX_OAUTH2_KEY': generated_values.get('BACKEND_SERVICE_EDX_OAUTH2_KEY'),
+                'BACKEND_SERVICE_EDX_OAUTH2_SECRET': generated_values.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
             }
         }
 

--- a/scripts/generate_ecommerce.py
+++ b/scripts/generate_ecommerce.py
@@ -90,8 +90,6 @@ def create_site_configuration(config, sites, partners):
                 'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': '{}/logout'.format(context['lms_url']),
                 'SOCIAL_AUTH_EDX_OAUTH2_KEY': generated_values.get('SOCIAL_AUTH_EDX_OAUTH2_KEY'),
                 'SOCIAL_AUTH_EDX_OAUTH2_SECRET': generated_values.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET'),
-                'BACKEND_SERVICE_EDX_OAUTH2_KEY': generated_values.get('BACKEND_SERVICE_EDX_OAUTH2_KEY'),
-                'BACKEND_SERVICE_EDX_OAUTH2_SECRET': generated_values.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
             }
         }
 

--- a/scripts/generate_lms.py
+++ b/scripts/generate_lms.py
@@ -130,14 +130,10 @@ def share_sso_credentials(config):
     from oauth2_provider.models import Application
 
     ecommerce_sso = Application.objects.get(name=config.oauth['ecommerce_sso_client'])
-    ecommerce_backend_service = Application.objects.get(name=config.oauth['ecommerce_backend_service_client'])
 
     write_generated_values({
         'SOCIAL_AUTH_EDX_OAUTH2_KEY': ecommerce_sso.client_id,
         'SOCIAL_AUTH_EDX_OAUTH2_SECRET': ecommerce_sso.client_secret,
-
-        'BACKEND_SERVICE_EDX_OAUTH2_KEY': ecommerce_backend_service.client_id,
-        'BACKEND_SERVICE_EDX_OAUTH2_SECRET': ecommerce_backend_service.client_secret,
     })
 
 

--- a/scripts/generate_lms.py
+++ b/scripts/generate_lms.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 import sys
 import os
 import logging
-from const import LMS_ROOT_DIR, ECOMMERCE_SSO_CLIENT
-from generator_utils import load_config, common_args, update_model, deep_merge
+from const import LMS_ROOT_DIR
+from generator_utils import load_config, common_args, update_model, deep_merge, write_generated_values
 
 
 logger = logging.getLogger(__name__)
@@ -98,16 +98,22 @@ def add_ecommerce_redirect_urls(config):
         config (Config)
     """
     from oauth2_provider.models import Application
+    from django.contrib.auth import get_user_model
 
     redirect_uris = []
     for code in config.get_microsite_codes():
         context = config.get_context(code)
         redirect_uris.append('{}/complete/edx-oauth2/'.format(context['ecommerce_url']))
 
-    # We expect ecommerce sso client to be present in the installation.
-    # Since it should be created as part of Open edX deployment.
-    # https://github.com/edx/configuration/blob/master/playbooks/roles/oauth_client_setup/defaults/main.yml
-    ecommerce_app = Application.objects.get(name=ECOMMERCE_SSO_CLIENT)
+    ecommerce_app, created = Application.objects.get_or_create(name=config.oauth['ecommerce_sso_client'])
+
+    if created:
+        ecommerce_app.client_type = 'confidential'
+        ecommerce_app.authorization_grant_type = 'authorization-code'
+        ecommerce_app.user = get_user_model().objects.get(username='ecommerce_worker')
+        ecommerce_app.skip_authorization = True
+        ecommerce_app.save()
+
     if ecommerce_app.redirect_uris:
         redirect_uris += ecommerce_app.redirect_uris.split()
 
@@ -115,6 +121,24 @@ def add_ecommerce_redirect_urls(config):
     logger.info('Adding ecommerce to redirect url {}'.format(redirect_uris_str))
     ecommerce_app.redirect_uris = redirect_uris_str
     ecommerce_app.save()
+
+
+def share_sso_credentials(config):
+    """
+    Writes OAuth client credentials in the shared generated config file.
+    """
+    from oauth2_provider.models import Application
+
+    ecommerce_sso = Application.objects.get(name=config.oauth['ecommerce_sso_client'])
+    ecommerce_backend_service = Application.objects.get(name=config.oauth['ecommerce_backend_service_client'])
+
+    write_generated_values({
+        'SOCIAL_AUTH_EDX_OAUTH2_KEY': ecommerce_sso.client_id,
+        'SOCIAL_AUTH_EDX_OAUTH2_SECRET': ecommerce_sso.client_secret,
+
+        'BACKEND_SERVICE_EDX_OAUTH2_KEY': ecommerce_backend_service.client_id,
+        'BACKEND_SERVICE_EDX_OAUTH2_SECRET': ecommerce_backend_service.client_secret,
+    })
 
 
 def run(config_file_path, settings_module):
@@ -138,6 +162,7 @@ def run(config_file_path, settings_module):
     sites = create_sites(config)
     create_site_configurations(config, sites)
     add_ecommerce_redirect_urls(config)
+    share_sso_credentials(config)
 
 
 if __name__ == '__main__':

--- a/scripts/generator_utils.py
+++ b/scripts/generator_utils.py
@@ -56,7 +56,6 @@ class Config:
     # LMS OAuth clients
     oauth = {
         'ecommerce_sso_client': 'custom-sites-ecommerce-sso',
-        'ecommerce_backend_service_client': 'ecommerce-backend-service',
     }
 
     # stores global override values

--- a/scripts/generator_utils.py
+++ b/scripts/generator_utils.py
@@ -1,5 +1,7 @@
 import yaml
+import os
 from argparse import ArgumentParser
+from const import GENERATED_SHARED_CONFIG_FILE
 
 
 def common_args() -> ArgumentParser:
@@ -51,6 +53,12 @@ class Config:
     # main domain to work with
     main_domain = None
 
+    # LMS OAuth clients
+    oauth = {
+        'ecommerce_sso_client': 'custom-sites-ecommerce-sso',
+        'ecommerce_backend_service_client': 'ecommerce-backend-service',
+    }
+
     # stores global override values
     global_overrides = {
         'overrides': {},
@@ -64,6 +72,11 @@ class Config:
         self._config = config
         self.organizations = config['organizations']
         self.main_domain = config['main_domain']
+
+        self.oauth = config.get(
+            'oauth',
+            self.oauth
+        )
 
         self._extract_microsites(config)
         self._extract_overrides(config)
@@ -215,3 +228,24 @@ def load_config(file_path) -> Config:
     with open(file_path) as file:
         config = yaml.load(file)
     return Config(config)
+
+
+def write_generated_values(data = {}):
+    """
+    Write new config value to the generated config file.
+    """
+    values = load_generated_values()
+    values.update(data)
+    with open(GENERATED_SHARED_CONFIG_FILE, 'w') as file:
+        yaml.dump(values, file)
+
+
+def load_generated_values():
+    """
+    Read config value from the generated config file.
+    """
+    values = {}
+    if os.path.exists(GENERATED_SHARED_CONFIG_FILE):
+        with open(GENERATED_SHARED_CONFIG_FILE) as file:
+            values = yaml.load(file)
+    return values


### PR DESCRIPTION
## Description

This PR fixes the issue reported in https://github.com/open-craft/microsite-generator/issues/2

## Supporting information

https://tasks.opencraft.com/browse/BB-4023

## Testing instructions

1. Pull this PR to `src` directory of your local devstack
2. Copy `config/sample.yaml` to `config/config.yaml`
3. To generate & test LMS configurations -
    - Login to LMS shell - `make lms-shell`
    - Go to microsite directory - `cd /edx/src/microsite-generator`
    - Run - `make dev.run-lms`
    - Check if a new OAuth client named `custom-sites-ecommerce-sso` has been created from LMS admin.
    - Check if there is a `config/_generated.yaml` file containing credential info.
5. To generate & test eCommerce configurations -
    - Login to eCommerce shell - `make ecommerce-shell`
    - Go to microsite directory - `cd /edx/src/microsite-generator`
    - Run - `make dev.run-ecommerce`
    - Check if `SiteConfiguration` has correct OAuth credentials from eCommerce admin.

## Deadline

None

## Reviewers

- [ ] @lgp171188
- [ ] @farhaanbukhsh 